### PR TITLE
Make Swagger server URL relative

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -7,8 +7,8 @@
   },
   "servers": [
     {
-      "url": "http://localhost:8990",
-      "description": "Default local REST API server"
+      "url": "/",
+      "description": "Use the same host and port serving the Swagger UI"
     }
   ],
   "paths": {


### PR DESCRIPTION
## Summary
- update the Swagger `servers` entry to use a relative base URL so the UI targets the current host

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cbaf05ae44832a9e6b7050781f12cb