### PR TITLE
Handle string inputSchema in GenerateEchartsPage

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,9 +197,21 @@ func GenerateEchartsPage(ctx context.Context, request mcp.CallToolRequest) (*mcp
 	// Safely extract parameters
 	args := request.GetArguments()
 
-	inputSchema, ok := args["inputSchema"].(map[string]interface{})
-	if !ok {
-		return mcp.NewToolResultError("Parameter 'inputSchema' must be a JSON object"), nil
+	rawInputSchema, exists := args["inputSchema"]
+	if !exists {
+		return mcp.NewToolResultError("Parameter 'inputSchema' must be provided"), nil
+	}
+
+	var inputSchema map[string]interface{}
+	switch value := rawInputSchema.(type) {
+	case map[string]interface{}:
+		inputSchema = value
+	case string:
+		if err := json.Unmarshal([]byte(value), &inputSchema); err != nil {
+			return mcp.NewToolResultError("Parameter 'inputSchema' must be a JSON object or JSON string"), nil
+		}
+	default:
+		return mcp.NewToolResultError("Parameter 'inputSchema' must be a JSON object or JSON string"), nil
 	}
 
 	title, ok := args["title"].(string)


### PR DESCRIPTION
## Summary
- allow GenerateEchartsPage to accept inputSchema provided as a JSON string
- keep support for object arguments and validate presence of the parameter

## Testing
- go test ./... *(fails: command hung while attempting to download modules, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68cbebea1214832a9a3ad2f05258683f