### PR TITLE
Support string inputSchema payloads on REST API

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -72,8 +72,16 @@
             "description": "Title of the chart page"
           },
           "inputSchema": {
-            "type": "object",
-            "description": "ECharts JSON configuration"
+            "description": "ECharts JSON configuration",
+            "oneOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "string",
+                "description": "Serialized ECharts JSON configuration"
+              }
+            ]
           },
           "width": {
             "type": "integer",

--- a/main.go
+++ b/main.go
@@ -50,10 +50,10 @@ type GenerateEchartsPageParams struct {
 // GenerateEchartsPageRequest models the REST API request body for
 // generating an ECharts page.
 type GenerateEchartsPageRequest struct {
-	Title       string                 `json:"title"`
-	InputSchema map[string]interface{} `json:"inputSchema"`
-	Width       *int                   `json:"width,omitempty"`
-	Height      *int                   `json:"height,omitempty"`
+	Title       string          `json:"title"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+	Width       *int            `json:"width,omitempty"`
+	Height      *int            `json:"height,omitempty"`
 }
 
 // GenerateEchartsPageResponse represents the REST API response body on success.
@@ -64,6 +64,9 @@ type GenerateEchartsPageResponse struct {
 const (
 	defaultChartWidth  = 1000
 	defaultChartHeight = 600
+
+	errInputSchemaRequired = "Parameter 'inputSchema' must be provided"
+	errInputSchemaFormat   = "Parameter 'inputSchema' must be a JSON object or JSON string"
 )
 
 func init() {
@@ -199,19 +202,12 @@ func GenerateEchartsPage(ctx context.Context, request mcp.CallToolRequest) (*mcp
 
 	rawInputSchema, exists := args["inputSchema"]
 	if !exists {
-		return mcp.NewToolResultError("Parameter 'inputSchema' must be provided"), nil
+		return mcp.NewToolResultError(errInputSchemaRequired), nil
 	}
 
-	var inputSchema map[string]interface{}
-	switch value := rawInputSchema.(type) {
-	case map[string]interface{}:
-		inputSchema = value
-	case string:
-		if err := json.Unmarshal([]byte(value), &inputSchema); err != nil {
-			return mcp.NewToolResultError("Parameter 'inputSchema' must be a JSON object or JSON string"), nil
-		}
-	default:
-		return mcp.NewToolResultError("Parameter 'inputSchema' must be a JSON object or JSON string"), nil
+	inputSchema, err := normalizeInputSchema(rawInputSchema)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	title, ok := args["title"].(string)
@@ -236,6 +232,48 @@ func GenerateEchartsPage(ctx context.Context, request mcp.CallToolRequest) (*mcp
 	}
 
 	return mcp.NewToolResultText(resultURL), nil
+}
+
+func normalizeInputSchema(raw interface{}) (map[string]interface{}, error) {
+	switch value := raw.(type) {
+	case map[string]interface{}:
+		return value, nil
+	case string:
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(value), &parsed); err != nil {
+			return nil, fmt.Errorf(errInputSchemaFormat)
+		}
+		return parsed, nil
+	case json.RawMessage:
+		return normalizeInputSchema([]byte(value))
+	case []byte:
+		trimmed := bytes.TrimSpace(value)
+		if len(trimmed) == 0 {
+			return nil, fmt.Errorf(errInputSchemaRequired)
+		}
+
+		if bytes.Equal(trimmed, []byte("null")) {
+			return nil, fmt.Errorf(errInputSchemaRequired)
+		}
+
+		if trimmed[0] == '{' {
+			var parsed map[string]interface{}
+			if err := json.Unmarshal(trimmed, &parsed); err != nil {
+				return nil, fmt.Errorf(errInputSchemaFormat)
+			}
+			return parsed, nil
+		}
+
+		var str string
+		if err := json.Unmarshal(trimmed, &str); err != nil {
+			return nil, fmt.Errorf(errInputSchemaFormat)
+		}
+		return normalizeInputSchema(str)
+	case nil:
+		return nil, fmt.Errorf(errInputSchemaRequired)
+	default:
+		return nil, fmt.Errorf(errInputSchemaFormat)
+	}
 }
 
 func renderAndPersistEchartsPage(params GenerateEchartsPageParams) (string, error) {
@@ -338,11 +376,6 @@ func handleGenerateEchartsPageAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.InputSchema == nil {
-		respondWithError(w, http.StatusBadRequest, "Parameter 'inputSchema' must be an object")
-		return
-	}
-
 	width := defaultChartWidth
 	if req.Width != nil {
 		width = *req.Width
@@ -353,9 +386,15 @@ func handleGenerateEchartsPageAPI(w http.ResponseWriter, r *http.Request) {
 		height = *req.Height
 	}
 
+	inputSchema, err := normalizeInputSchema(req.InputSchema)
+	if err != nil {
+		respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
 	params := GenerateEchartsPageParams{
 		Title:       req.Title,
-		InputSchema: req.InputSchema,
+		InputSchema: inputSchema,
 		Width:       width,
 		Height:      height,
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHandleGenerateEchartsPageAPIWithObjectInputSchema(t *testing.T) {
+	staticDir := t.TempDir()
+	t.Setenv("STATIC_DIR", staticDir)
+
+	body := `{"title":"Test Chart","inputSchema":{"xAxis":{"type":"category"},"series":[{"type":"line","data":[1,2,3]}]}}`
+	resp := executeGenerateEchartsPageRequest(t, body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var payload GenerateEchartsPageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+
+	if payload.URL == "" {
+		t.Fatalf("expected a non-empty URL in response")
+	}
+
+	assertChartFileExists(t, staticDir, payload.URL)
+}
+
+func TestHandleGenerateEchartsPageAPIWithStringInputSchema(t *testing.T) {
+	staticDir := t.TempDir()
+	t.Setenv("STATIC_DIR", staticDir)
+
+	body := `{"title":"Test Chart","inputSchema":"{\"xAxis\":{\"type\":\"value\"},\"series\":[{\"type\":\"bar\",\"data\":[4,5,6]}]}"}`
+	resp := executeGenerateEchartsPageRequest(t, body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var payload GenerateEchartsPageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+
+	if payload.URL == "" {
+		t.Fatalf("expected a non-empty URL in response")
+	}
+
+	assertChartFileExists(t, staticDir, payload.URL)
+}
+
+func executeGenerateEchartsPageRequest(t *testing.T, body string) *http.Response {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/GenerateEchartsPage", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	handleGenerateEchartsPageAPI(recorder, req)
+
+	resp := recorder.Result()
+	t.Cleanup(func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("failed to close response body: %v", err)
+		}
+	})
+
+	return resp
+}
+
+func assertChartFileExists(t *testing.T, staticDir, urlStr string) {
+	t.Helper()
+
+	parsed, err := url.Parse(urlStr)
+	if err != nil {
+		t.Fatalf("failed to parse response URL: %v", err)
+	}
+
+	if !strings.HasPrefix(parsed.Path, "/charts/") {
+		t.Fatalf("unexpected chart URL path: %s", parsed.Path)
+	}
+
+	fileName := path.Base(parsed.Path)
+	filePath := filepath.Join(staticDir, "charts", fileName)
+
+	if _, err := os.Stat(filePath); err != nil {
+		t.Fatalf("expected generated chart file at %s: %v", filePath, err)
+	}
+}


### PR DESCRIPTION
## Summary
- allow the REST request model to accept raw JSON for inputSchema and share parsing with the MCP handler
- normalize REST validation so renderAndPersistEchartsPage always receives a decoded map and returns consistent errors
- document the new inputSchema formats in the OpenAPI spec and add handler tests for JSON object and string payloads

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cbf176a5d0832a89fe343c14a878e0