### PR TITLE
Add configurable CORS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ API_PORT=8990
 # Service public URL (used to generate chart page links)
 PUBLIC_URL=http://localhost:8989
 
+# Comma-separated list of allowed CORS origins (use * to allow all)
+CORS_ALLOWED_ORIGINS=
+
 # Log level (optional values: trace, debug, info, warn, error, fatal, panic)
 LOG_LEVEL=info
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The `.env` file supports the following settings:
 - `PORT`: The port for both MCP requests and static file hosting (default: `8989`).
 - `API_PORT`: The port for the REST API exposing `/api/GenerateEchartsPage` and `/docs` (default: `8990`).
 - `PUBLIC_URL`: The public URL of the service (default: `http://localhost:8989`).
+- `CORS_ALLOWED_ORIGINS`: Comma-separated list of origins allowed to access static pages and REST endpoints (for example `http://10.2.142.66:5173` or `*`).
 - `LOG_LEVEL`: Logging level (for example `info`, `debug`).
 - `STATIC_DIR`: Directory for generated static HTML files (default: `static`).
 

--- a/main.go
+++ b/main.go
@@ -86,6 +86,8 @@ func init() {
 }
 
 func main() {
+	allowedOrigins := parseAllowedOrigins(getEnv("CORS_ALLOWED_ORIGINS", ""))
+
 	// Create the MCP server
 	s := server.NewMCPServer(
 		"ECharts Visualization Page Service", // MCP service for generating ECharts pages
@@ -143,7 +145,7 @@ func main() {
 	// Build the shared HTTP server
 	httpServer := &http.Server{
 		Addr:    ":" + port,
-		Handler: mux,
+		Handler: withCORS(mux, allowedOrigins),
 	}
 
 	// Configure the REST API server
@@ -154,7 +156,7 @@ func main() {
 	apiMux.HandleFunc("/docs", swaggerUIHandler("/swagger.json"))
 	apiServer := &http.Server{
 		Addr:    ":" + apiPort,
-		Handler: apiMux,
+		Handler: withCORS(apiMux, allowedOrigins),
 	}
 
 	// Start the HTTP server
@@ -457,6 +459,54 @@ func respondWithJSON(w http.ResponseWriter, status int, payload interface{}) {
 
 func respondWithError(w http.ResponseWriter, status int, message string) {
 	respondWithJSON(w, status, map[string]string{"error": message})
+}
+
+func withCORS(handler http.Handler, allowedOrigins []string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if origin := r.Header.Get("Origin"); origin != "" && isOriginAllowed(origin, allowedOrigins) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Vary", "Origin")
+			w.Header().Set("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		}
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		handler.ServeHTTP(w, r)
+	})
+}
+
+func parseAllowedOrigins(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	var origins []string
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			origins = append(origins, trimmed)
+		}
+	}
+
+	return origins
+}
+
+func isOriginAllowed(origin string, allowedOrigins []string) bool {
+	if len(allowedOrigins) == 0 {
+		return false
+	}
+
+	for _, allowed := range allowedOrigins {
+		if allowed == "*" || strings.EqualFold(allowed, origin) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getTemplate() string {


### PR DESCRIPTION
## Summary
- add configurable CORS middleware applied to static, MCP, and REST routes
- allow specifying allowed origins via the CORS_ALLOWED_ORIGINS environment variable and document it

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691edeab0770832aa003903e6d07f902)